### PR TITLE
Sidebar categories are no longer covered by header

### DIFF
--- a/app/src/Homepage/Homepage.css
+++ b/app/src/Homepage/Homepage.css
@@ -15,8 +15,9 @@
 /* Sidebar css */
 .sidebar {
   background-color: #F0F0F0;
-  height: 100%;
+  height: 89%;
   width: 15%;
+  bottom: 0%;
   position: fixed;
 }
 

--- a/app/src/Homepage/Homepage.css
+++ b/app/src/Homepage/Homepage.css
@@ -14,7 +14,7 @@
 
 /* Sidebar css */
 .sidebar {
-  background-color: #F0F0F0;
+  background-color: #f0f0f0;
   height: 89%;
   width: 15%;
   bottom: 0%;


### PR DESCRIPTION
- Shortened sidebar to no longer overlap with header, so that course categories rendered at the top or sidebar are not covered
- Made the corresponding adjustment to have the header flush with bottom of screen

Testing
- Sidebar still adjusts proportionally to window resizing
- Saw that sidebar buttons are no longer hidden by header