### PR TITLE
cbuendia/route tab pages

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.18.58",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.18.0",
         "react-scripts": "^5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -2978,6 +2979,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
+      "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13083,6 +13092,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
+      "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
+      "dependencies": {
+        "@remix-run/router": "1.11.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.18.0.tgz",
+      "integrity": "sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==",
+      "dependencies": {
+        "@remix-run/router": "1.11.0",
+        "react-router": "6.18.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^16.18.58",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.18.0",
     "react-scripts": "^5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/app/src/Homepage/Homepage-components.test.tsx
+++ b/app/src/Homepage/Homepage-components.test.tsx
@@ -1,14 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import { LevelTab } from './Homepage-components';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 test('Renders LevelTab components with correct names', () => {
   render(
-    <>
-      <LevelTab classlevel='test1' />
-      <LevelTab classlevel='random' />
-      <LevelTab classlevel='123' />
-      <LevelTab classlevel='class' />
-    </>
+    <div>
+      <Router>
+        <LevelTab classlevel='test1' />
+        <LevelTab classlevel='random' />
+        <LevelTab classlevel='123' />
+        <LevelTab classlevel='class' />
+      </Router>
+    </div>
   );
 
   const tab1 = screen.getByText('test1');

--- a/app/src/Homepage/Homepage-components.test.tsx
+++ b/app/src/Homepage/Homepage-components.test.tsx
@@ -1,5 +1,5 @@
 import {render, screen} from '@testing-library/react';
-import {LevelTab} from './Homepage-components';
+import {GetStringAfterSpace, LevelTab} from './Homepage-components';
 import {BrowserRouter as Router} from 'react-router-dom';
 
 test('Renders LevelTab components with correct names', () => {
@@ -25,4 +25,14 @@ test('Renders LevelTab components with correct names', () => {
   expect(tab4).toBeInTheDocument();
 });
 
+test('GetWordAfterSpace returns string of text after space', () => {
+  const str1 = "CSE 900s"
+  const str2 = "100 200"
+  const str3 = "CSE 403"
+  const str4 = "word1 word2"
 
+  expect(GetStringAfterSpace(str1)).toEqual("900s");
+  expect(GetStringAfterSpace(str2)).toEqual("200");
+  expect(GetStringAfterSpace(str3)).toEqual("403");
+  expect(GetStringAfterSpace(str4)).toEqual("word2");
+});

--- a/app/src/Homepage/Homepage-components.test.tsx
+++ b/app/src/Homepage/Homepage-components.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
-import { LevelTab } from './Homepage-components';
-import { BrowserRouter as Router } from 'react-router-dom';
+import {render, screen} from '@testing-library/react';
+import {LevelTab} from './Homepage-components';
+import {BrowserRouter as Router} from 'react-router-dom';
 
 test('Renders LevelTab components with correct names', () => {
   render(

--- a/app/src/Homepage/Homepage-components.test.tsx
+++ b/app/src/Homepage/Homepage-components.test.tsx
@@ -1,5 +1,5 @@
 import {render, screen} from '@testing-library/react';
-import {GetStringAfterSpace, LevelTab} from './Homepage-components';
+import {GetClassNumber, LevelTab} from './Homepage-components';
 import {BrowserRouter as Router} from 'react-router-dom';
 
 test('Renders LevelTab components with correct names', () => {
@@ -25,14 +25,14 @@ test('Renders LevelTab components with correct names', () => {
   expect(tab4).toBeInTheDocument();
 });
 
-test('GetWordAfterSpace returns string of text after space', () => {
+test('GetClassNumber returns class number after space', () => {
   const str1 = "CSE 900s"
   const str2 = "100 200"
   const str3 = "CSE 403"
-  const str4 = "word1 word2"
+  const str4 = "CSE 5050505"
 
-  expect(GetStringAfterSpace(str1)).toEqual("900s");
-  expect(GetStringAfterSpace(str2)).toEqual("200");
-  expect(GetStringAfterSpace(str3)).toEqual("403");
-  expect(GetStringAfterSpace(str4)).toEqual("word2");
+  expect(GetClassNumber(str1)).toEqual("900s");
+  expect(GetClassNumber(str2)).toEqual("200");
+  expect(GetClassNumber(str3)).toEqual("403");
+  expect(GetClassNumber(str4)).toEqual("5050505");
 });

--- a/app/src/Homepage/Homepage-components.tsx
+++ b/app/src/Homepage/Homepage-components.tsx
@@ -1,4 +1,25 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+type LayoutProps = {
+    children: React.ReactNode;
+}
+
+export const Layout: React.FC<LayoutProps> = ( props: LayoutProps ) => {
+    return (
+        <div className='App'>
+            <Header/>
+            <Sidebar>
+                <LevelTab classlevel='Home'/>
+                <LevelTab classlevel='100s'/>
+                <LevelTab classlevel='300s'/>
+                <LevelTab classlevel='400s'/>
+                <LevelTab classlevel='500s'/>
+            </Sidebar>
+            {props.children}
+        </div>
+    );
+}
 
 export const Header: React.FC = () => {
     return (
@@ -22,17 +43,29 @@ export const Sidebar: React.FC<SidebarProps> = ( props: SidebarProps ) => {
 
 
 export const LevelTab: React.FC<{ classlevel: string }> = ({ classlevel }) => {   
+    const navigate = useNavigate();
     
     const handleClick = () => {
         console.log('Button clicked: ' + classlevel);
-        
+        if (classlevel === 'Home') {
+            navigate('/rate-my-cse/');
+        } else {
+            navigate('/rate-my-cse/cse' + classlevel);
+        }
     };
+
+    let label : string;
+    if (classlevel === 'Home') {
+        label = classlevel;
+    } else {
+        label = 'CSE ' + classlevel;
+    }
     
     return (
         <button className="leveltab" data-testid={`levelTab-${classlevel}`}
                 onClick={ handleClick }
         >
-            {classlevel}
+            {label}
         </button>
     );
 }

--- a/app/src/Homepage/Homepage-components.tsx
+++ b/app/src/Homepage/Homepage-components.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {useNavigate} from 'react-router-dom';
+import {GetDefaultRoute} from '../utils';
 
 type LayoutProps = {
     children: React.ReactNode;
@@ -47,14 +48,12 @@ export const LevelTab: React.FC<{ classlevel: string }> = ({ classlevel }) => {
     
     const handleClick = () => {
         if (classlevel === 'Home') {
-            // If 'Home' button, route to default homepage
-            navigate('/rate-my-cse/');
+            // Default route
+            navigate('/' + GetDefaultRoute() + '/');
         } else {
-            // Else 'CSE X00s' button, split classlevel into an array of
-            // tokens by the " " delimiter and get second element, 'X00s', 
-            // to route to corresponding '/cseX00s' page
+            // Gets correct 'X00s' from classlevel and routes to that page
             const levelWithoutCSE : string = classlevel.split(" ", 2)[1];
-            navigate('/rate-my-cse/cse' + levelWithoutCSE);
+            navigate('/' + GetDefaultRoute() + '/cse' + levelWithoutCSE);
         }
     };
     

--- a/app/src/Homepage/Homepage-components.tsx
+++ b/app/src/Homepage/Homepage-components.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import {useNavigate} from 'react-router-dom';
 
 type LayoutProps = {
     children: React.ReactNode;
@@ -46,11 +46,15 @@ export const LevelTab: React.FC<{ classlevel: string }> = ({ classlevel }) => {
     const navigate = useNavigate();
     
     const handleClick = () => {
-        console.log('Button clicked: ' + classlevel);
         if (classlevel === 'Home') {
+            // If 'Home' button, route to default homepage
             navigate('/rate-my-cse/');
         } else {
-            navigate('/rate-my-cse/cse' + classlevel.split(" ", 2)[1]);
+            // Else 'CSE X00s' button, split classlevel into an array of
+            // tokens by the " " delimiter and get second element, 'X00s', 
+            // to route to corresponding '/cseX00s' page
+            const levelWithoutCSE : string = classlevel.split(" ", 2)[1];
+            navigate('/rate-my-cse/cse' + levelWithoutCSE);
         }
     };
     

--- a/app/src/Homepage/Homepage-components.tsx
+++ b/app/src/Homepage/Homepage-components.tsx
@@ -7,7 +7,7 @@ type LayoutProps = {
 
 export const HomeLayout: React.FC<LayoutProps> = ( props: LayoutProps ) => {
     return (
-        <div className='App'>
+        <div className='homelayout'>
             <Header/>
             <Sidebar>
                 <LevelTab classlevel='Home'/>

--- a/app/src/Homepage/Homepage-components.tsx
+++ b/app/src/Homepage/Homepage-components.tsx
@@ -42,6 +42,9 @@ export const Sidebar: React.FC<SidebarProps> = ( props: SidebarProps ) => {
     );
 }
 
+export const GetStringAfterSpace = ( label : string ) => {
+    return label.split(" ", 2)[1];
+}
 
 export const LevelTab: React.FC<{ classlevel: string }> = ({ classlevel }) => {   
     const navigate = useNavigate();
@@ -51,9 +54,8 @@ export const LevelTab: React.FC<{ classlevel: string }> = ({ classlevel }) => {
             // Default route
             navigate('/' + GetDefaultRoute() + '/');
         } else {
-            // Gets correct 'X00s' from classlevel and routes to that page
-            const levelWithoutCSE : string = classlevel.split(" ", 2)[1];
-            navigate('/' + GetDefaultRoute() + '/cse' + levelWithoutCSE);
+            // Gets 'X00s' from 'CSE X00s' classlevel and routes to that page
+            navigate('/' + GetDefaultRoute() + '/cse' + GetStringAfterSpace(classlevel));
         }
     };
     

--- a/app/src/Homepage/Homepage-components.tsx
+++ b/app/src/Homepage/Homepage-components.tsx
@@ -11,10 +11,10 @@ export const HomeLayout: React.FC<LayoutProps> = ( props: LayoutProps ) => {
             <Header/>
             <Sidebar>
                 <LevelTab classlevel='Home'/>
-                <LevelTab classlevel='100s'/>
-                <LevelTab classlevel='300s'/>
-                <LevelTab classlevel='400s'/>
-                <LevelTab classlevel='500s'/>
+                <LevelTab classlevel='CSE 100s'/>
+                <LevelTab classlevel='CSE 300s'/>
+                <LevelTab classlevel='CSE 400s'/>
+                <LevelTab classlevel='CSE 500s'/>
             </Sidebar>
             {props.children}
         </div>
@@ -50,22 +50,15 @@ export const LevelTab: React.FC<{ classlevel: string }> = ({ classlevel }) => {
         if (classlevel === 'Home') {
             navigate('/rate-my-cse/');
         } else {
-            navigate('/rate-my-cse/cse' + classlevel);
+            navigate('/rate-my-cse/cse' + classlevel.split(" ", 2)[1]);
         }
     };
-
-    let label : string;
-    if (classlevel === 'Home') {
-        label = classlevel;
-    } else {
-        label = 'CSE ' + classlevel;
-    }
     
     return (
         <button className="leveltab" data-testid={`levelTab-${classlevel}`}
                 onClick={ handleClick }
         >
-            {label}
+            {classlevel}
         </button>
     );
 }

--- a/app/src/Homepage/Homepage-components.tsx
+++ b/app/src/Homepage/Homepage-components.tsx
@@ -42,7 +42,7 @@ export const Sidebar: React.FC<SidebarProps> = ( props: SidebarProps ) => {
     );
 }
 
-export const GetStringAfterSpace = ( label : string ) => {
+export const GetClassNumber = ( label : string ) => {
     return label.split(" ", 2)[1];
 }
 
@@ -55,7 +55,7 @@ export const LevelTab: React.FC<{ classlevel: string }> = ({ classlevel }) => {
             navigate('/' + GetDefaultRoute() + '/');
         } else {
             // Gets 'X00s' from 'CSE X00s' classlevel and routes to that page
-            navigate('/' + GetDefaultRoute() + '/cse' + GetStringAfterSpace(classlevel));
+            navigate('/' + GetDefaultRoute() + '/cse' + GetClassNumber(classlevel));
         }
     };
     

--- a/app/src/Homepage/Homepage-components.tsx
+++ b/app/src/Homepage/Homepage-components.tsx
@@ -5,7 +5,7 @@ type LayoutProps = {
     children: React.ReactNode;
 }
 
-export const Layout: React.FC<LayoutProps> = ( props: LayoutProps ) => {
+export const HomeLayout: React.FC<LayoutProps> = ( props: LayoutProps ) => {
     return (
         <div className='App'>
             <Header/>

--- a/app/src/Homepage/Homepage.test.tsx
+++ b/app/src/Homepage/Homepage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import App from './Homepage';
 
 test('Checks App has correct button names and in order within the sidebar', () => {

--- a/app/src/Homepage/Homepage.tsx
+++ b/app/src/Homepage/Homepage.tsx
@@ -7,11 +7,11 @@ function App() {
     <BrowserRouter>
       <HomeLayout>
         <Routes>
-          <Route path="rate-my-cse/" element={<InnerPage/>} />
-          <Route path="rate-my-cse/cse100s" element="cse100s page"/>
-          <Route path="rate-my-cse/cse300s" element="cse300s page"/>
-          <Route path="rate-my-cse/cse400s" element="cse400s page"/>
-          <Route path="rate-my-cse/cse500s" element="cse500s page"/>
+          <Route path='rate-my-cse/' element={<InnerPage/>} />
+          <Route path='rate-my-cse/cse100s' element='cse100s page'/>
+          <Route path='rate-my-cse/cse300s' element='cse300s page'/>
+          <Route path='rate-my-cse/cse400s' element='cse400s page'/>
+          <Route path='rate-my-cse/cse500s' element='cse500s page'/>
         </Routes>
       </HomeLayout>
     </BrowserRouter>

--- a/app/src/Homepage/Homepage.tsx
+++ b/app/src/Homepage/Homepage.tsx
@@ -1,26 +1,20 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import {Header, Sidebar, LevelTab, InnerPage, Layout} from './Homepage-components';
+import {InnerPage, HomeLayout} from './Homepage-components';
 import './Homepage.css';
 
 function App() {
   return (
     <BrowserRouter>
-      <Layout>
+      <HomeLayout>
         <Routes>
-          <Route path="rate-my-cse/" element={<Homepage/>} />
+          <Route path="rate-my-cse/" element={<InnerPage/>} />
           <Route path="rate-my-cse/cse100s" element="cse100s page"/>
           <Route path="rate-my-cse/cse300s" element="cse300s page"/>
           <Route path="rate-my-cse/cse400s" element="cse400s page"/>
           <Route path="rate-my-cse/cse500s" element="cse500s page"/>
         </Routes>
-      </Layout>
+      </HomeLayout>
     </BrowserRouter>
-  );
-}
-
-function Homepage() {
-  return (
-      <InnerPage/>
   );
 }
 

--- a/app/src/Homepage/Homepage.tsx
+++ b/app/src/Homepage/Homepage.tsx
@@ -1,5 +1,6 @@
 import {BrowserRouter as Router, Route, Routes} from 'react-router-dom';
 import {InnerPage, HomeLayout} from './Homepage-components';
+import {GetDefaultRoute} from '../utils';
 import './Homepage.css';
 
 function App() {
@@ -7,11 +8,11 @@ function App() {
     <Router>
       <HomeLayout>
         <Routes>
-          <Route path='rate-my-cse/' element={<InnerPage/>} />
-          <Route path='rate-my-cse/cse100s' element='cse100s page'/>
-          <Route path='rate-my-cse/cse300s' element='cse300s page'/>
-          <Route path='rate-my-cse/cse400s' element='cse400s page'/>
-          <Route path='rate-my-cse/cse500s' element='cse500s page'/>
+          <Route path={GetDefaultRoute() + '/'} element={<InnerPage/>} />
+          <Route path={GetDefaultRoute() + '/cse100s'} element='cse100s page'/>
+          <Route path={GetDefaultRoute() + '/cse300s'} element='cse300s page'/>
+          <Route path={GetDefaultRoute() + '/cse400s'} element='cse400s page'/>
+          <Route path={GetDefaultRoute() + '/cse500s'} element='cse500s page'/>
         </Routes>
       </HomeLayout>
     </Router>

--- a/app/src/Homepage/Homepage.tsx
+++ b/app/src/Homepage/Homepage.tsx
@@ -1,10 +1,10 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import {InnerPage, HomeLayout} from './Homepage-components';
 import './Homepage.css';
 
 function App() {
   return (
-    <BrowserRouter>
+    <Router>
       <HomeLayout>
         <Routes>
           <Route path='rate-my-cse/' element={<InnerPage/>} />
@@ -14,7 +14,7 @@ function App() {
           <Route path='rate-my-cse/cse500s' element='cse500s page'/>
         </Routes>
       </HomeLayout>
-    </BrowserRouter>
+    </Router>
   );
 }
 

--- a/app/src/Homepage/Homepage.tsx
+++ b/app/src/Homepage/Homepage.tsx
@@ -1,19 +1,26 @@
-import {Header, Sidebar, LevelTab, InnerPage} from './Homepage-components';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import {Header, Sidebar, LevelTab, InnerPage, Layout} from './Homepage-components';
 import './Homepage.css';
 
 function App() {
   return (
-    <div className='App'>
-      <Header/>
-      <Sidebar>
-        <LevelTab classlevel='Home'/>
-        <LevelTab classlevel='CSE 100s'/>
-        <LevelTab classlevel='CSE 300s'/>
-        <LevelTab classlevel='CSE 400s'/>
-        <LevelTab classlevel='CSE 500s'/>
-      </Sidebar>
+    <BrowserRouter>
+      <Layout>
+        <Routes>
+          <Route path="rate-my-cse/" element={<Homepage/>} />
+          <Route path="rate-my-cse/cse100s" element="cse100s page"/>
+          <Route path="rate-my-cse/cse300s" element="cse300s page"/>
+          <Route path="rate-my-cse/cse400s" element="cse400s page"/>
+          <Route path="rate-my-cse/cse500s" element="cse500s page"/>
+        </Routes>
+      </Layout>
+    </BrowserRouter>
+  );
+}
+
+function Homepage() {
+  return (
       <InnerPage/>
-    </div>
   );
 }
 

--- a/app/src/Homepage/Homepage.tsx
+++ b/app/src/Homepage/Homepage.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import {BrowserRouter as Router, Route, Routes} from 'react-router-dom';
 import {InnerPage, HomeLayout} from './Homepage-components';
 import './Homepage.css';
 

--- a/app/src/utils.test.tsx
+++ b/app/src/utils.test.tsx
@@ -4,5 +4,4 @@ test('GetDefaultRoute always returns default route name', () => {
     const str1 = GetDefaultRoute();
 
     expect(str1).toEqual("rate-my-cse");
-    expect(str1).toEqual(GetDefaultRoute());
 });

--- a/app/src/utils.test.tsx
+++ b/app/src/utils.test.tsx
@@ -1,0 +1,8 @@
+import { GetDefaultRoute } from "./utils";
+
+test('GetDefaultRoute always returns default route name', () => {
+    const str1 = GetDefaultRoute();
+
+    expect(str1).toEqual("rate-my-cse");
+    expect(str1).toEqual(GetDefaultRoute());
+});

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -1,0 +1,4 @@
+
+export const GetDefaultRoute = () => {
+    return "rate-my-cse";
+}


### PR DESCRIPTION
- Added React Router to configuration
- Replaced App render with Router to pages (homepage, X00s pages)
- Put what was previously in App render in a new Layout component that encompasses all home + directory pages (so that header and sidebar is on each page)
- Sidebar buttons now route to separate pages defined by Router (filled in HandleClick function to do so)

Testing
- Saw URL changes when clicking on buttons, but header and sidebar remain
- Saw that otherwise layout remains the same, even when scaling window
- Saw that Homepage still contains blue InnerPage but directory pages do not