### PR TITLE
Changed CSS to Resize Text

### DIFF
--- a/app/src/Homepage/Homepage.css
+++ b/app/src/Homepage/Homepage.css
@@ -8,13 +8,20 @@
   right: 5%;
   min-height: 200vh;
   text-align: center;
+  padding: 3%;
 }
 
 /* Welcome header */
 .welcome {
   text-align: center;
-  margin-top: 60px;
-  font-size: 300%;
+  margin-top: clamp(1px, 60px, 15vw);
+  font-size: clamp(1px, 300%, 9vw);
+}
+
+/* Header tagline */
+.tagline {
+  font-size: clamp(1px, 16px, 4vw);
+  margin-bottom: clamp(0px, 6vh, 10vw);
 }
 
 /* How it works: header */
@@ -22,30 +29,32 @@
   top: 15%;
   height: 50%;
   width: 100%;
+  font-size: clamp(1px, 16px, 4vw);
 }
 
 /* Explanation below the How it works: header */
 .explanation {
   font-weight: normal;
+  font-size: clamp(1px, 16px, 4vw);
 }
 
 .ratingsflexbox {
   display: flex;
   justify-content: space-around;
-  min-height: 11%;
-  width: 100%;
 }
 
 /* The rating boxes for difficulty, workload, and practicality */
 .ratingbox {
   font-weight: bold;
-  font-size: 130%;
+  font-size: clamp(1px, 130%, 3vw);
   display: flex;
   align-items: center;
   align-self: flex-end;
   justify-content: center;
   height: 10vh;
-  min-width: 12vw;
+  max-height: 8ch;
+  width: 12vw;
+  min-width: 10ch;
 }
 
 /* Rating box colors */
@@ -69,6 +78,7 @@
   color: gray;
   word-wrap: break-word;
   white-space: normal;
-  padding-top: 10px;
+  padding-top: clamp(1px, 10px, 2vw);
   width: 16vw;
+  font-size: clamp(1px, 16px, 2vw);
 }

--- a/app/src/Homepage/Homepage.tsx
+++ b/app/src/Homepage/Homepage.tsx
@@ -6,7 +6,7 @@ export const HomePage: React.FC = () => {
             <h1 className="welcome">
                 Welcome to RateMyCSE
             </h1>
-            <h3>Wondering if a UW CSE class is as hard as they say?</h3>
+            <h3 className="tagline">Wondering if a UW CSE class is as hard as they say?</h3>
             <div className="howitworks">
                 <h2>How it works:</h2>
                 <h3 className="explanation">

--- a/app/src/Layout/Layout.css
+++ b/app/src/Layout/Layout.css
@@ -45,7 +45,7 @@
   display: inline-block;
   border: none;
   margin-top: 4%;
-  font-size: clamp(1px, 140%, 4vw);
+  font-size: clamp(1px, 140%, 3vw);
   color: black;
   text-decoration: none;
 }

--- a/app/src/Layout/Layout.css
+++ b/app/src/Layout/Layout.css
@@ -1,9 +1,3 @@
-/* Both header and sidebar */
-.homelayout {
-  position: fixed;
-  z-index: 1000;
-}
-
 /* Header css */
 .header {
   background-color: #4b2e83;
@@ -13,6 +7,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  z-index: 1;
 }
 
 .logo {

--- a/app/src/Layout/Layout.css
+++ b/app/src/Layout/Layout.css
@@ -1,10 +1,15 @@
+/* Both header and sidebar */
+.homelayout {
+  position: fixed;
+  z-index: 1000;
+}
+
 /* Header css */
 .header {
   background-color: #4b2e83;
   height: 11vh;
   width: 100%;
   position: fixed;
-  z-index: 1;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -33,7 +38,7 @@
   background-color: #f0f0f0;
   height: 89vh;
   width: 15%;
-  bottom: 0%;
+  top: 11vh;
   position: fixed;
 }
 

--- a/app/src/Layout/Layout.css
+++ b/app/src/Layout/Layout.css
@@ -45,7 +45,7 @@
   display: inline-block;
   border: none;
   margin-top: 4%;
-  font-size: 140%;
+  font-size: clamp(1px, 140%, 4vw);
 }
 
 .leveltab:hover,

--- a/app/src/Layout/Layout.css
+++ b/app/src/Layout/Layout.css
@@ -46,6 +46,8 @@
   border: none;
   margin-top: 4%;
   font-size: clamp(1px, 140%, 4vw);
+  color: black;
+  text-decoration: none;
 }
 
 .leveltab:hover,

--- a/app/src/Layout/Layout.tsx
+++ b/app/src/Layout/Layout.tsx
@@ -6,7 +6,7 @@ type LayoutProps = {
 
 export const HomeLayout: React.FC<LayoutProps> = ( props: LayoutProps ) => {
     return (
-        <div className="homelayout">
+        <div className='homelayout'>
             <Header>
                 <Logo/>
                 <Login/>

--- a/app/src/Layout/Layout.tsx
+++ b/app/src/Layout/Layout.tsx
@@ -6,20 +6,18 @@ type LayoutProps = {
 
 export const HomeLayout: React.FC<LayoutProps> = ( props: LayoutProps ) => {
     return (
-        <div>
-            <div className="homelayout">
-                <Header>
-                    <Logo/>
-                    <Login/>
-                </Header>
-                <Sidebar>
-                    <LevelTab classlevel='Home'/>
-                    <LevelTab classlevel='CSE 100s'/>
-                    <LevelTab classlevel='CSE 300s'/>
-                    <LevelTab classlevel='CSE 400s'/>
-                    <LevelTab classlevel='CSE 500s'/>
-                </Sidebar>
-            </div>
+        <div className="homelayout">
+            <Header>
+                <Logo/>
+                <Login/>
+            </Header>
+            <Sidebar>
+                <LevelTab classlevel='Home'/>
+                <LevelTab classlevel='CSE 100s'/>
+                <LevelTab classlevel='CSE 300s'/>
+                <LevelTab classlevel='CSE 400s'/>
+                <LevelTab classlevel='CSE 500s'/>
+            </Sidebar>
             {props.children}
         </div>
     );

--- a/app/src/Layout/Layout.tsx
+++ b/app/src/Layout/Layout.tsx
@@ -6,18 +6,20 @@ type LayoutProps = {
 
 export const HomeLayout: React.FC<LayoutProps> = ( props: LayoutProps ) => {
     return (
-        <div className='homelayout'>
-            <Header>
-                <Logo/>
-                <Login/>
-            </Header>
-            <Sidebar>
-                <LevelTab classlevel='Home'/>
-                <LevelTab classlevel='CSE 100s'/>
-                <LevelTab classlevel='CSE 300s'/>
-                <LevelTab classlevel='CSE 400s'/>
-                <LevelTab classlevel='CSE 500s'/>
-            </Sidebar>
+        <div>
+            <div className="homelayout">
+                <Header>
+                    <Logo/>
+                    <Login/>
+                </Header>
+                <Sidebar>
+                    <LevelTab classlevel='Home'/>
+                    <LevelTab classlevel='CSE 100s'/>
+                    <LevelTab classlevel='CSE 300s'/>
+                    <LevelTab classlevel='CSE 400s'/>
+                    <LevelTab classlevel='CSE 500s'/>
+                </Sidebar>
+            </div>
             {props.children}
         </div>
     );


### PR DESCRIPTION
- Changed Homepage text CSS so that text size would shrink with a smaller width window
- Changed sidebar course tab CSS for the same effect
- Changed sidebar CSS so the vertical position is defined by the top rather than the bottom (looks the same on PC, but fixes a scrolling issue when viewing on mobile)
- Slight CSS changes like removal of trivial fields

Testing:
- Viewed on Vercel preview on both PC and mobile, and saw that text shrunk with width and no longer overflowed from visual containers