### PR TITLE
Made top portion of course page resizable

### DIFF
--- a/app/src/CoursePages/CoursePage.css
+++ b/app/src/CoursePages/CoursePage.css
@@ -63,13 +63,14 @@
   gap: 1rem;
 }
 
-.course-num {
+.course-title-num {
   text-wrap: nowrap;
+  font-size: clamp(1px, 200%, 15vw);
   margin: 0;
 
 }
 
-.course-name {
+.course-title-name {
   text-wrap: balance;
   margin: 0;
 }

--- a/app/src/CoursePages/CoursePage.css
+++ b/app/src/CoursePages/CoursePage.css
@@ -11,31 +11,6 @@
   justify-content: space-around;
 }
 
-.overallratingbox {
-  font-weight: bold;
-  font-size: clamp(1px, 130%, 3vw);
-  display: flex;
-  align-items: center;
-  align-self: flex-end;
-  justify-content: center;
-  height: 15vh;
-  max-height: 4ch;
-  min-width: 3ch;
-  width: 8vw;
-}
-
-.overallratingbox-Difficulty {
-  background-color: #e087e2;
-}
-
-.overallratingbox-Workload {
-  background-color: #8dbbff;
-}
-
-.overallratingbox-Practicality {
-  background-color: #88ecaa;
-}
-
 /* CSS styling for the top portion of the course page */
 
 .top-box {
@@ -78,7 +53,8 @@
 
 .course-desc {
   text-align: left;
-  max-width: 30rem;
+  font-size: clamp(1px, 16px, 1.5vw);
+  width: clamp(5rem, 45vw, 50rem);
   height: auto;
   text-wrap: balance;
 }
@@ -97,7 +73,7 @@
   padding: 1.8%;
   border: none;
   outline: none;
-  font-size: 1.04rem;
+  font-size: clamp(1px, 1.04rem, 1.75vw);
   font-weight: 700;
 }
 
@@ -116,7 +92,7 @@
 }
 
 .overall-ratings-header {
-  font-size: 1.75rem;
+  font-size: clamp(1px, 1.75rem, 4vw);
   margin: 0 0 2.5rem 0;
 }
 
@@ -124,6 +100,45 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+}
+
+/* Media query for screens with a maximum width of 600px */
+@media (max-width: 1004px) {
+  .ratings-flexbox {
+    flex-direction: column;
+  }
+
+  .overall-rating-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .overall-ratings-header {
+    margin: 0 0 1.5rem;
+  }
+}
+
+.overallratingbox {
+  font-weight: bold;
+  font-size: clamp(1px, 130%, 2.5vw);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-height: 4ch;
+  width: clamp(3ch, 8vw, 9vw);
+}
+
+.overallratingbox-Difficulty {
+  background-color: #e087e2;
+}
+
+.overallratingbox-Workload {
+  background-color: #8dbbff;
+}
+
+.overallratingbox-Practicality {
+  background-color: #88ecaa;
 }
 
 /* CSS styling for the bottom portion of the course page (the reviews) */

--- a/app/src/CoursePages/CoursePage.tsx
+++ b/app/src/CoursePages/CoursePage.tsx
@@ -82,8 +82,8 @@ export const CourseInfo: React.FC<CourseInfoProps> = (props) => {
         <div className="course-info">
             <div className="left-flexbox">
                 <div className="course-title">
-                    <h1 className="course-num">{ "CSE " + props.classNum }</h1>
-                    <h2 className="course-name">{ props.courseName }</h2>
+                    <h1 className="course-title-num">{ "CSE " + props.classNum }</h1>
+                    <h2 className="course-title-name">{ props.courseName }</h2>
                 </div>
                 <p className="course-desc">{ props.desc }</p>
                 <div className="buttons-flexbox">

--- a/app/src/CoursePages/CoursePage.tsx
+++ b/app/src/CoursePages/CoursePage.tsx
@@ -115,7 +115,8 @@ export const OverallRatingBox: React.FC<{label: string, rating: string}> = ({ la
     }
 
     const category: React.CSSProperties = {
-       margin: 1.5
+       margin: 1.5,
+       fontSize: `clamp(1px, 117%, 2vw)`,
     };
 
     return (


### PR DESCRIPTION
- Added media query CSS properties to make the overall rating boxes go from a row to a column when the screen is thin
- Moved some CSS properties around to make it in neater sections
- Made course info text and buttons resizable

Testing:
- Used vercel and Google Web Dev to play around with sizing to make sure display was consistent