### PR TITLE
Add Loading to Account Pages + CSS changes

### DIFF
--- a/app/src/CoursePages/CoursePage.tsx
+++ b/app/src/CoursePages/CoursePage.tsx
@@ -34,7 +34,7 @@ export const CoursePage: React.FC = () => {
         <div className="coursepage">
             <div className="top-box">
                 <CourseInfo classNum={ classNum! }
-                courseName={ course.length > 0 ? course[0].name : '...' }
+                courseName={ course.length > 0 ? course[0].name : '' }
                 desc={ course.length > 0 ? course[0].description : '' }
                 loaded={course.length > 0}/>
                 <div className="right-flexbox">

--- a/app/src/Login/Login.css
+++ b/app/src/Login/Login.css
@@ -11,14 +11,14 @@
   align-items: center;
 }
 
-@media (max-width: 800px) {
+@media (max-width: 600px) {
   .loginpage, .signuppage {
     background-color: #f0f0f0;
     position: absolute;
     top: 15%;
     left: 32.5%;
     right: 17.5%;
-    min-height: 75vh;
+    min-height: 78vh;
     text-align: center;
     display: flex;
     flex-direction: column;

--- a/app/src/Login/Login.css
+++ b/app/src/Login/Login.css
@@ -44,3 +44,7 @@
   flex-direction: column;
   align-items: center;
 }
+
+.loading-comps {
+  margin-top: 1vw;
+}

--- a/app/src/Login/Login.css
+++ b/app/src/Login/Login.css
@@ -1,48 +1,52 @@
-.loginpage {
+.loginpage, .signuppage {
   background-color: #f0f0f0;
   position: absolute;
   top: 15%;
-  left: 30%;
-  right: 30%;
+  left: 37.5%;
+  right: 22.5%;
   min-height: 80vh;
-  min-width: fit-content;
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
+@media (max-width: 800px) {
+  .loginpage, .signuppage {
+    background-color: #f0f0f0;
+    position: absolute;
+    top: 15%;
+    left: 32.5%;
+    right: 17.5%;
+    min-height: 75vh;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
 .loginpage h1, .signuppage h1 {
-  margin-top: 10%;
+  font-weight: 700;
+  font-size: clamp(1px, 34px, 7vw);
+  margin-top: 6.6vh;
   margin-bottom: 6%;
   user-select: none;
 }
 
-.signup {
-  font-size: 2.3vh;
+.signup, .signin {
+  font-size: clamp(1px, 16px, 3vw); 
   user-select: none;
 }
 
 #forgot-psw, #sign-up-button, #sign-in-button {
   color: #2400ff;
-  font-size: 2vh; 
+  background-color: inherit;
+  font-size: clamp(1px, 16px, 3vw); 
   font-weight: 700;
   margin: 2%;
   border: none;
   cursor: pointer;
-}
-
-.signuppage {
-  background-color: #f0f0f0;
-  position: absolute;
-  top: 15%;
-  left: 30%;
-  right: 30%;
-  height: 80vh;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 }
 
 .loading-comps {

--- a/app/src/Login/Login.css
+++ b/app/src/Login/Login.css
@@ -28,7 +28,7 @@
 
 .loginpage h1, .signuppage h1 {
   font-weight: 700;
-  font-size: clamp(1px, 34px, 7vw);
+  font-size: clamp(1px, 34px, 9vw);
   margin-top: 6.6vh;
   margin-bottom: 6%;
   user-select: none;

--- a/app/src/Login/LoginPage.tsx
+++ b/app/src/Login/LoginPage.tsx
@@ -148,7 +148,7 @@ export const LoginPage: React.FC = () => {
                     width: '45%',
                     bgcolor: 'black',
                     textTransform: 'none',
-                    fontSize: '2.5vh'
+                    fontSize: 'clamp(1px, 20px, 2.8vw)'
                 }}
             >
                 Continue

--- a/app/src/Login/LoginPage.tsx
+++ b/app/src/Login/LoginPage.tsx
@@ -29,6 +29,7 @@ export const LoginPage: React.FC = () => {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [isInvalidLogin, setIsInvalidLogin] = useState('');
+    const [loading, setLoading] = useState(false);
     const navigate = useNavigate();
 
     const [users, setUsers] = useState<any[]>([]);
@@ -49,6 +50,7 @@ export const LoginPage: React.FC = () => {
     });
 
     function handleSubmit() {
+        setLoading(true);
         authenticate(email,password)
           .then(async (data)=>{
             isUserSignedIn = true;
@@ -57,8 +59,10 @@ export const LoginPage: React.FC = () => {
             if (users.length === 0) await postUser(user);
 
             // Navigate back to home page
+            setLoading(false);
             navigate('../');
           },(err)=>{
+            setLoading(false);
             setIsInvalidLogin('Username or password is incorrect');
           })
     }
@@ -149,6 +153,15 @@ export const LoginPage: React.FC = () => {
             >
                 Continue
             </Button>
+
+            {loading && 
+                <div className='loading-comps'>
+                    <div className='loading-spinner center'/>
+                    <div className='loading-text'>
+                        Logging in...
+                    </div>
+                </div>
+            }
 
             <Box
                 sx={{

--- a/app/src/Login/SignupPage.tsx
+++ b/app/src/Login/SignupPage.tsx
@@ -204,8 +204,8 @@ export const SignupPage: React.FC = () => {
                     width: '45%',
                     bgcolor: 'black',
                     textTransform: 'none',
-                    fontSize: '2.5vh',
-                    marginTop: '5%'
+                    fontSize: 'clamp(1px, 20px, 2.8vw)',
+                    marginTop: '5%',
                 }}
             >
                 Verify UW Email
@@ -229,7 +229,7 @@ export const SignupPage: React.FC = () => {
                     fontWeight: 700,
                 }}
             >
-                <p>Already have an account?
+                <p className='signin'>Already have an account?
                     <button
                         id='sign-in-button'
                         onClick={() => handleSignin()}

--- a/app/src/Login/SignupPage.tsx
+++ b/app/src/Login/SignupPage.tsx
@@ -21,6 +21,7 @@ export const SignupPage: React.FC = () => {
     const [isPsw2Invalid, setIsPsw2Invalid] = useState(false);
     const [psw2HelperText, setPsw2HelperText] = useState('');
     const [users, setUsers] = useState<any[]>([]);
+    const [loading, setLoading] = useState(false);
     const navigate = useNavigate();
 
     async function handleSubmit() {
@@ -68,7 +69,9 @@ export const SignupPage: React.FC = () => {
             setPsw2HelperText('');
         }
 
+        setLoading(true);
         handleSignup();
+        setLoading(false);
     }
 
     const handleSignup = async () => {
@@ -103,6 +106,7 @@ export const SignupPage: React.FC = () => {
                         // Not verified yet
                         if (users.length === 0) {
                             setIsEmailInvalid(true);
+                            setLoading(false);
                             setEmailHelperText('Account already signed up. Please verify this account.');
                             cognitoUser.resendConfirmationCode((resendErr, result) => {
                                 if (resendErr) {
@@ -111,14 +115,17 @@ export const SignupPage: React.FC = () => {
                             });
                         } else {
                             setIsEmailInvalid(true);
+                            setLoading(false);
                             setEmailHelperText('User is already verified. Please sign in.');
                         }
                     }
                 } else {
+                    setLoading(false);
                     navigate('/login');
                 }
             });
         } catch (error) {
+            setLoading(false);
             console.error('Error:', error);
         }
     };
@@ -203,6 +210,15 @@ export const SignupPage: React.FC = () => {
             >
                 Verify UW Email
             </Button>
+
+            {loading && 
+                <div className='loading-comps'>
+                    <div className='loading-spinner center'/>
+                    <div className='loading-text'>
+                        Loading...
+                    </div>
+                </div>
+            }
 
             <Box
                 sx={{


### PR DESCRIPTION
- Added Loading spinners to both Login and Signup pages during their data fetches
- Centered the Login and Signup pages
- Made the pages' text resizable
- Added a slightly wider resize for smaller width screens
- Unrelated: Took off the loading header '...' from the Course page because it was redundant with the Loading... spinner

Testing
- Viewed, resized, and inspected on Vercel preview, on PC and mobile
- Logged in on Vercel preview and saw the loading spinner before redirect (Note: Signup was too fast to confirm, but viewed in npm start local run)