### PR TITLE
Replaced Placeholder with Email on Review Submit

### DIFF
--- a/app/src/Rating/Rating.tsx
+++ b/app/src/Rating/Rating.tsx
@@ -1,7 +1,8 @@
-import {useNavigate, useParams} from "react-router-dom";
+import {Link, useNavigate, useParams} from "react-router-dom";
 import {useEffect, useState} from "react";
 import {Comment, InputField, RatingDesc, RatingScale, ReviewHeader} from "./Rating-components";
-import {getEmail} from "../Login/LoginPage";
+import {getEmail, getSignInStatus} from "../Login/LoginPage";
+import Popup from "../Popup/Popup";
 import './Rating.css'
 
 export const ReviewPage: React.FC = () => {
@@ -70,10 +71,16 @@ export const ReviewHolder: React.FC<{classNum : string}> = ({classNum}) => {
         professor: 'N/A'
     };
     const [ratingContents, setRatingContents] = useState<ReviewState>(initialState);
+    const [popupOpen, setPopupOpen] = useState(!getSignInStatus());
 
     const navigate = useNavigate();
 
     const handleBackClick = () => {
+        navigate('/course/' + classNum);
+    }
+
+    const closePopup = () => {
+        setPopupOpen(false);
         navigate('/course/' + classNum);
     }
 
@@ -95,6 +102,14 @@ export const ReviewHolder: React.FC<{classNum : string}> = ({classNum}) => {
 
     return (
         <div className="rating-inputs">
+            {popupOpen && 
+                <Popup onClose={closePopup} header="Login to Review">
+                    <p>You must be logged in with a UW email address to leave a review.</p>
+                    <p>
+                        Click here to <Link to="/login" onClick={() => setPopupOpen(false)}>Login</Link> or <Link to="/signup" onClick={() => setPopupOpen(false)}>Sign Up</Link>
+                    </p>
+                </Popup>
+            }
             <div className="scales">
                 <RatingScale category={1} setReview={setRatingContents}/>
                 <RatingScale category={2} setReview={setRatingContents}/>

--- a/app/src/Rating/Rating.tsx
+++ b/app/src/Rating/Rating.tsx
@@ -1,6 +1,7 @@
 import {useNavigate, useParams} from "react-router-dom";
 import {useEffect, useState} from "react";
 import {Comment, InputField, RatingDesc, RatingScale, ReviewHeader} from "./Rating-components";
+import {getEmail} from "../Login/LoginPage";
 import './Rating.css'
 
 export const ReviewPage: React.FC = () => {
@@ -59,7 +60,7 @@ export interface ReviewState {
 
 export const ReviewHolder: React.FC<{classNum : string}> = ({classNum}) => {
     const initialState : ReviewState = {
-        reviewer: 'test_user',  
+        reviewer: getEmail(),  
         rating_one: 0, 
         rating_two: 0, 
         rating_three: 0,


### PR DESCRIPTION
- Replaced the 'review' field of a Review to be posted to the DB with the email of the user
- Added a popup to the Review page that tells a non-logged-in user they must be logged in (discovered the workaround where a user can log in, get to the Review page, log out, click back, then review -- this prevents that)

Testing
- Opened in Vercel preview, logged in, added a review, then saw in MySQL that it was under my email instead of test_user
- Re-ran the bug on Vercel where a non-logged in user can navigate back to the Review page and saw that reviewing was blocked by a popup, then was directed back to the course page upon closing