### PR TITLE
Added submit on enter for signup and login pages

### DIFF
--- a/app/src/Login/LoginPage.tsx
+++ b/app/src/Login/LoginPage.tsx
@@ -75,6 +75,12 @@ export const LoginPage: React.FC = () => {
         alert('Can\'t do much! Try again');
     }
 
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+            handleSubmit();
+        }
+    };
+
     async function postUser(username: string) {
         try {
             const response = await fetch(`/api/PostUser?name=${username}`, {
@@ -110,6 +116,7 @@ export const LoginPage: React.FC = () => {
                     onInput={ (e) => {
                         setEmail((e.target as HTMLInputElement).value)
                     }}
+                    onKeyDown={handleKeyDown}
                 />
             </Box>
 
@@ -132,6 +139,7 @@ export const LoginPage: React.FC = () => {
                         setPassword((e.target as HTMLInputElement).value)
                     }}
                     InputProps={{endAdornment: <EyeAdornment visible={visible} setVisible={setVisible}/>}}
+                    onKeyDown={handleKeyDown}
                 />
             </Box>
 

--- a/app/src/Login/SignupPage.tsx
+++ b/app/src/Login/SignupPage.tsx
@@ -139,6 +139,12 @@ export const SignupPage: React.FC = () => {
         navigate('/login');
     }
 
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+            handleSubmit();
+        }
+    };
+
     return (
         <div className='signuppage'>
             {popupOpen &&
@@ -166,6 +172,7 @@ export const SignupPage: React.FC = () => {
                     onInput={ (e) => {
                         setEmail((e.target as HTMLInputElement).value)
                     }}
+                    onKeyDown={handleKeyDown}
                 />
             </Box>
 
@@ -187,6 +194,7 @@ export const SignupPage: React.FC = () => {
                         setPsw1((e.target as HTMLInputElement).value)
                     }}
                     InputProps={{endAdornment: <EyeAdornment visible={visible} setVisible={setVisible}/>}}
+                    onKeyDown={handleKeyDown}
                 />
             </Box>
 
@@ -208,6 +216,7 @@ export const SignupPage: React.FC = () => {
                         setPsw2((e.target as HTMLInputElement).value)
                     }}
                     InputProps={{endAdornment: <EyeAdornment visible={visible} setVisible={setVisible}/>}}
+                    onKeyDown={handleKeyDown}
                 />
             </Box>
 


### PR DESCRIPTION
- Added submit on enter for input fields for Signup and Login pages

Testing
- Opened in Vercel preview and pressing enter had the same function as pressing the Submit button for all text fields on both pages
- _Assurance: pressing enter when the user is typing on one of these pages' input fields will submit for that page, not for the search bar (and opposite if user is typing in search bar), as by default with input focus_