### PR TITLE
Fixed caps issues on search bar

### DIFF
--- a/app/src/utils/utils.tsx
+++ b/app/src/utils/utils.tsx
@@ -14,10 +14,10 @@ export const SearchBar: React.FC<SearchBarProps> = ({ isHeader }) => {
             isHeader ? '.header-search-bar' : '.search-bar'
         );
         if (searchInput && searchInput.value !== '') {
-            const searchString = searchInput.value;
+            const searchString = searchInput.value.toLowerCase();
 
             // Replaces all strings and instances of CSE
-            const stringWithoutSpacesOrCSE = searchString.replace(/\s|CSE|cse/g, '');
+            const stringWithoutSpacesOrCSE = searchString.replace(/\s|cse/g, '');
 
             navigate(`/search/${stringWithoutSpacesOrCSE}`);
         }


### PR DESCRIPTION
- Search bar could not handle caps

Testing:
- Saw on Vercel that different cap permutation of cse work (including space and no space)