### PR TITLE
Added hide/reveal password toggle options for the ResetPswPage

### DIFF
--- a/app/src/Login/ResetPswPage.tsx
+++ b/app/src/Login/ResetPswPage.tsx
@@ -5,6 +5,7 @@ import {MuiOtpInput} from 'mui-one-time-password-input';
 import {checkPswValid} from './loginUtils';
 import {CognitoUser} from 'amazon-cognito-identity-js';
 import {getCognitoUserPoolAsync} from '../userpool';
+import {EyeAdornment} from './LoginPage';
 import Popup from "../Popup/Popup";
 import './Login.css'
 
@@ -15,7 +16,9 @@ export const ResetPswPage: React.FC = () => {
     const navigate = useNavigate();
     const [email, setEmail] = useState('');
     const [psw1, setPsw1] = useState('');
+    const [visible1, setVisible1] = useState(false);
     const [psw2, setPsw2] = useState('');
+    const [visible2, setVisible2] = useState(false);
     const [isEmailInvalid, setIsEmailInvalid] = useState(false);
     const [emailHelperText, setEmailHelperText] = useState('');
     const [isPsw1Invalid, setIsPsw1Invalid] = useState(false);
@@ -220,6 +223,7 @@ export const ResetPswPage: React.FC = () => {
                 }}
             >
                 <TextField
+                    type={visible1 ? 'text' : 'password'}
                     error={isPsw1Invalid}
                     helperText={psw1HelperText}
                     fullWidth
@@ -230,6 +234,7 @@ export const ResetPswPage: React.FC = () => {
                     onInput={ (e) => {
                         setPsw1((e.target as HTMLInputElement).value)
                     }}
+                    InputProps={{endAdornment: <EyeAdornment visible={visible1} setVisible={setVisible1}/>}}
                 />
             </Box>
 
@@ -240,6 +245,7 @@ export const ResetPswPage: React.FC = () => {
                 }}
             >
                 <TextField
+                    type={visible2 ? 'text' : 'password'}
                     error={isPsw2Invalid}
                     helperText={psw2HelperText}
                     fullWidth
@@ -250,6 +256,7 @@ export const ResetPswPage: React.FC = () => {
                     onInput={ (e) => {
                         setPsw2((e.target as HTMLInputElement).value)
                     }}
+                    InputProps={{endAdornment: <EyeAdornment visible={visible2} setVisible={setVisible2}/>}}
                 />
             </Box>
 


### PR DESCRIPTION
- Did as the title says

Testing: 
- Deployed locally to Vercel and proceeded to reset password and typed in both password fields to test the toggle icons for the respective fields